### PR TITLE
Login Behavior / Inactive Users Authenticates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,4 @@ install:
   - pip install "$DJANGO"
   - pip install .
   - pip install -r testapp/requirements.txt
-script:
-  – python -Wall testapp/manage.py test
+script: python -Wall testapp/manage.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
-  - "3.3"
   - "3.4"
+  - "3.5"
 install: 
     pip install .
     pip install -r testapp/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
+sudo: false
 language: python
 python:
   - "2.7"
   - "3.4"
   - "3.5"
-install: 
-    pip install .
-    pip install -r testapp/requirements.txt
+env:
+  - DJANGO="django>=1.8,<1.9"
+  - DJANGO="django>=1.9,<1.10"
+install:
+  - pip install "$DJANGO"
+  - pip install .
+  - pip install -r testapp/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ install:
   - pip install "$DJANGO"
   - pip install .
   - pip install -r testapp/requirements.txt
+script:
+  – python -Wall testapp/manage.py test

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ There are two things you need to do in `settings.py`
 
 1. Define a function that can return a dictionary with fields that
 are required by your user model, e.g. `USER_DATA_FN = 'django_ssl_auth.fineid.user_dict_from_dn` is a sample implementation that takes the required fields from the DN of a Finnish government issued ID smart card for the `contrib.auth.models.User`.
-2. To automatically create `User`s for all valid certificate holders, set `AUTOCREATE_VALID_SSL_USERS = True`
+2. To automatically create `User`s for all valid certificate holders, set `AUTOCREATE_VALID_SSL_USERS = True`. Auto-created users will be set to inactive by default, consider using the [`User.is_active`](https://docs.djangoproject.com/en/1.9/ref/contrib/auth/#django.contrib.auth.models.User.is_active) field in your [`LOGIN_DIRECT_URL`](https://docs.djangoproject.com/en/1.9/ref/settings/#login-redirect-url) view to notifying the user of their status.
 
 For details, see `testapp/ssltest/settings.py`
 

--- a/django_ssl_auth/base.py
+++ b/django_ssl_auth/base.py
@@ -71,9 +71,6 @@ class SSLClientAuthBackend(object):
                 user.save()
             else:
                 return None
-        if not user.is_active:
-            logger.warning("user {0} inactive".format(username))
-            return None
         logger.info("user {0} authenticated using a certificate issued to "
                     "{1}".format(username, dn))
         return user

--- a/django_ssl_auth/base.py
+++ b/django_ssl_auth/base.py
@@ -26,6 +26,8 @@ import logging
 from django.conf import settings
 from django.contrib.auth import login, authenticate
 from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpResponseRedirect
+from django.shortcuts import resolve_url
 from importlib import import_module
 
 try:
@@ -89,13 +91,17 @@ class SSLClientAuthMiddleware(object):
             raise ImproperlyConfigured()
         if request.user.is_authenticated():
             return
-        user = authenticate(request=request)
-        if user is None or not user.is_authenticated():
-            return
         if int(request.META.get('HTTP_X_REST_API', 0)):
-            request.user = user
+            user = authenticate(request=request)
+            if user is None or not user.is_authenticated():
+                return
             logger.debug("REST API call, not logging user in")
-        else:
+            request.user = user
+        elif request.path_info == settings.LOGIN_URL:
+            user = authenticate(request=request)
+            if user is None or not user.is_authenticated():
+                return
             logger.info("Logging user in")
             login(request, user)
+            return HttpResponseRedirect(resolve_url(settings.LOGIN_REDIRECT_URL))
 

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(name='django-ssl-auth',
       author_email='kimvais@ssh.com',
       url='https://github.com/kimvais/django-ssl-client-auth/',
       packages=['django_ssl_auth'],
-      requires=['Django (>=1.4)']
+      requires=['Django (>=1.8)']
 )

--- a/testapp/requirements.txt
+++ b/testapp/requirements.txt
@@ -1,3 +1,3 @@
 Django>=1.8.0
-django-ssl-auth>=0.8.2.3
+django-ssl-auth>=1.0.0
 gunicorn

--- a/testapp/requirements.txt
+++ b/testapp/requirements.txt
@@ -1,3 +1,3 @@
-Django>=1.5.4
+Django>=1.8.0
 django-ssl-auth>=0.8.2.3
 gunicorn

--- a/testapp/ssltest/settings.py
+++ b/testapp/ssltest/settings.py
@@ -100,6 +100,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django_ssl_auth.SSLClientAuthMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
 )
 
 ROOT_URLCONF = 'ssltest.urls'

--- a/testapp/ssltest/settings.py
+++ b/testapp/ssltest/settings.py
@@ -158,6 +158,15 @@ LOGGING = {
     }
 }
 
+LOGIN_REDIRECT_URL = 'home'
+LOGIN_URL = ('/login')
+
 AUTHENTICATION_BACKENDS = ('django_ssl_auth.SSLClientAuthBackend', )
 USER_DATA_FN = 'django_ssl_auth.fineid.user_dict_from_dn'
 AUTOCREATE_VALID_SSL_USERS = True
+
+# This setting is used for testing so that the test cases can simulate
+# an https connection to Django. Please see the Django documentation
+# and understand this setting before considering using it in your own site.
+# https://docs.djangoproject.com/en/1.9/ref/settings/#secure-proxy-ssl-header
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTOCOL', 'https')

--- a/testapp/ssltest/tests.py
+++ b/testapp/ssltest/tests.py
@@ -1,0 +1,28 @@
+from django.test import TestCase
+from django.contrib.auth.models import AnonymousUser, User
+from django.core.urlresolvers import reverse
+
+class Tests(TestCase):
+    """Automated tests to ensure everything is working as designed."""
+    
+    def test_login_new_user(self):
+        """Ensure users are automatically created."""
+        
+        # Make sure the user doesn't already exist.
+        with self.assertRaises(User.DoesNotExist):
+            User.objects.get(username='1')
+        
+        # Simulate an SSL connection (of a new user)
+        response = self.client.get('/login',
+                                    HTTP_X_SSL_AUTHENTICATED='SUCCESS',
+                                    HTTP_X_SSL_USER_DN='C=FI/serialNumber=1/GN=John/SN=Smith/CN=John Smith',
+                                    HTTP_X_FORWARDED_PROTOCOL='https')
+        
+        # Ensure the new user was created
+        try:
+            user = User.objects.get(username='1')
+        except:
+            self.fail("New user wasn't created.")
+        
+        self.assertEqual(user.first_name, 'John', str('First name was incorrect.'))
+        self.assertEqual(user.last_name, 'Smith', str('Last name was incorrect.'))

--- a/testapp/ssltest/urls.py
+++ b/testapp/ssltest/urls.py
@@ -5,7 +5,7 @@ from django.conf.urls import patterns, include, url
 # admin.autodiscover()
 from . import views
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^fi/?$', views.Fineid.as_view(), name='fi'),
     url(r'^$', views.Test.as_view(), name='home'),
-)
+]


### PR DESCRIPTION
This PR changes two behaviors, adds test cases, Django updates and updates the docs as appropriate.

Behavior Update 1) Only attempt login if the request path is the login URL (specified by settings.LOGIN_URL), as part of this, redirect the user to settings.LOGIN_REDIRECT_URL which is the expected behavior of an auth backend. This fixes the issue where users would not be able to logout and clear the session from the browser as after they logged out, they would be immediately logged back in.

Behavior Update 2) Do not check the is_active flag when authenticating users. This normalizes the behavior with the default Django backends. This has the additional benefit of allowing the developer to check for is_active in the login view and prompt inactive users with a note regarding the status of their account.

General updates include having Travis CI test with Python 2.7, 3.4 and 3.5 and Django 1.8 and 1.9 (and any warnings / deprecations were fixed). A basic test case was setup that uses a client that sets the appropriate HTTP headers of an ssl-client-auth connection and verifies that the user was created and logged in.
