### PR TITLE
Update the middleware to work with Django 1.10+ style middleware

### DIFF
--- a/django_ssl_auth/base.py
+++ b/django_ssl_auth/base.py
@@ -26,6 +26,10 @@ import logging
 from django.conf import settings
 from django.contrib.auth import login, authenticate
 from django.core.exceptions import ImproperlyConfigured
+try:
+    from django.utils.deprecation import MiddlewareMixin  # Django 1.10+
+except ImportError:
+    MiddlewareMixin = object  # Django < 1.10
 from importlib import import_module
 
 try:
@@ -83,7 +87,7 @@ class SSLClientAuthBackend(object):
             return None
 
 
-class SSLClientAuthMiddleware(object):
+class SSLClientAuthMiddleware(MiddlewareMixin):
     def process_request(self, request):
         if not hasattr(request, 'user'):
             raise ImproperlyConfigured()


### PR DESCRIPTION
This allows users to use the new `MIDDLEWARE` setting introduced in Django 1.10, as mentioned [here](https://docs.djangoproject.com/en/1.11/releases/1.10/#new-style-middleware) and documented [here](https://docs.djangoproject.com/en/1.11/topics/http/middleware/#upgrading-middleware).

This also continues to work with earlier versions of Django still utilizing `MIDDLEWARE_CLASSES`.